### PR TITLE
Using JWT for user info instead of front-end props. Additionally fixed the likedUser matching to current user.

### DIFF
--- a/front-end/src/Comment.js
+++ b/front-end/src/Comment.js
@@ -42,7 +42,7 @@ const Comment = props => {
         <section className="body">
           <pre>
             <p>{indent(props.type)}{props.details.text}</p>
-            {/* <p>{indent(props.type)}<LikeButton></LikeButton>likes: {props.details.likes}</p> */}
+            {/* <p>{indent(props.type)}<LikeButton props={props}></LikeButton>likes: {props.details.likes}</p> */}
           </pre>
         </section>
       </div>

--- a/front-end/src/Components/likeButton.js
+++ b/front-end/src/Components/likeButton.js
@@ -5,6 +5,10 @@ import axios from "axios"
 import "./likeButton.scss";
 
 /*
+1. Use JWT to get user
+2. Compare User to all User objects in Comment.likedUsers
+3. 
+
 This component is the like button. It should be applicable on Post objects and Comment objects (For now, only handling comments).
 Since each like button is only associated with a single Post or Comment object, I do NOT need to render all comments associated with a single post in the state of this component.
 Most of the bread and butter of this component is housed in the back-end/app.js file.
@@ -15,18 +19,23 @@ voteComment() assumes that Comment.likedUsers is an array of userId's.
 const particleList = Array.from(Array(10));
 
 const LikeButton = (props) => {
+  const jwtToken = localStorage.getItem('token')
   
+  const [accountInfo, setAccountInfo] = useState({})
   const [comment, setComment] = useState([])
-  // completely unnecessary for now, but in the future, loaded and setLoaded states will help
+
+  // loaded/setLoaded is completely unnecessary for now, but in the future, loaded and setLoaded states will help
   const [loaded, setLoaded] = useState(false)
 
   // setComment to whatever is returned from the api request
   const fetchComment = () => {
-    // body of the request
+ 
     const payload = {
-      'comment_id':props.details.comment_id
+      // QUESTION 1: how do I access the comment_id from within a component?
+      'comment_id':props.comment_id
     }
     axios
+    // QUESTION 2: how do I access the gameId and postId from within a component?
       .post(`${process.env.REACT_APP_SERVER_HOSTNAME}/megathread/${props.gameId}/subthread/${props.postId}/comments/search`, payload)
       .then(response => {
         const comment = response.data.comment
@@ -43,21 +52,27 @@ const LikeButton = (props) => {
 
   // the function that changes the value of the current comment's likes and likedUsers
   const voteComment = () => {
-    // sets likes and likedUsers to what they currently are
+
     const likes = props.details.likes
     const likedUsers = [props.details.likedUsers]
-    // loops through every user in the current list of likedUsers to find a match
-    for (const user in props.details.likedUsers) {
-      // if a match is found, then it removes that user from the likedUser list and decreases the likes count by 1 (it's removing their like)
-      if (props.user_id === user) {
-        const index = likedUsers.indexOf(props.user_id)
+
+    // first convert all the User objects in the likedUser array into an array of their usernames
+    const mappedUsers = props.details.likedUsers.map(user => user.username);
+
+    // if a match is found, then it removes that user from the likedUser list and decreases the likes count by 1 (it's removing their like)
+    for (const username in mappedUsers) {
+      if (accountInfo.username === username) {
+        const index = mappedUsers.indexOf(accountInfo.username)
+
+        // since all I did was map the usernames to a new array, the indexes are exactly the same in the mappedUsers array and the likedUsers array
         likedUsers.splice(index, 1); likes--;
       }
     }
+
     // checks if the likes count is the same (if it is not then it was decremented above and this conditional should be ignored)
+    // then adds the user to the likedUser list and increments the likes count.
     if (likes === props.details.likes) {
-      // then adds the user to the likedUser list and increments the likes count.
-      likedUsers.push(props.user_id); likes++;
+      likedUsers.push(accountInfo); likes++;
     }
 
     // body of the post request to the endpoint to update a comment
@@ -69,11 +84,11 @@ const LikeButton = (props) => {
     axios
       .post(`${process.env.REACT_APP_SERVER_HOSTNAME}/megathread/${props.gameId}/subthread/${props.postId}/comments`, payload)
       .then(response => {
-        // endpoint returns an array of all comments associated with the post, so I have to loop through again
+        // endpoint returns an updated array of all comments associated with the post, so I have to loop through again
         const newComments = response.data.comments
         for (const i in newComments) {
-          if (i.comment_id === props.details.comment_id) {
-            // updates the current state of the comment in the front end
+          if (i.comment_id === props.comment_id) {
+            // updates the state of the comment in the front end
             setComment(i)
           }
         }
@@ -96,7 +111,24 @@ const LikeButton = (props) => {
   }
 
   useEffect(() => {
-    fetchComment()
+    axios
+    .get(`${process.env.REACT_APP_SERVER_HOSTNAME}/isLoggedIn`, {
+        headers: { Authorization: `JWT ${jwtToken}` }
+    })
+    .then(res => {
+        if(res.data.success){
+            setAccountInfo(res.data.user)
+            fetchComment()
+          }
+          else{
+                alert("You must be signed in to use the Like button!")
+          }
+    })
+    .catch(err => {
+        if(err){
+            alert("Access denied! You don't have permission to use the Like button.")
+        }
+    })
   }, [])
   
   return (


### PR DESCRIPTION
Using JWT to retrieve user info instead of passing the user state on the front-end. Also fixed the matching of likedUsers to the current logged in user, now it is checking the usernames of each user in the likedUsers object then comparing it to the username of the user parsed from the JWT.